### PR TITLE
feat: trusted dealer key generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,7 @@ jobs:
 
     - name: Run Unit Tests
       run: go test
+    
+    - name: Integration Tests
+      run: cd tests/integration && go test
+

--- a/README.md
+++ b/README.md
@@ -24,12 +24,38 @@ go install github.com/soatok/frost@latest
 
 ### Key Generation
 
-This package currently does **NOT** implement key generation.
+#### Trusted Dealer
 
-In the future, we will implement two key generation strategies in submodules:
+```go
+import (
+	"github.com/soatok/trusteddealer"
+	"github.com/soatok/frost"
+)
 
-1. Honest Dealer (simpler, but requires a trusted party)
-2. An Ed25519 variant of ChillDKG
+func main() {
+	// We are using the default ciphersuite:
+	c := frost.DefaultCiphersuite()
+	dealer := trusteddealer.NewTrustedDealer(c)
+
+	// This is a 3-of-4 threshold:
+	participants := uint32(4)
+	threshold := uint32(3)
+	keygen, err := td.Keygen(participants, threshold)
+
+	// Group public key:
+	publicKey := keygen.GroupPublicKey.Bytes()
+
+	// Commitments:
+	commitments := keygen.Commitments()
+
+	// Send shares to each party:
+	for i := range keygen.Count() {
+		id := keygen.Participants[i].Identifier.Bytes()
+		secret := keygen.ParticipantPrivateKeys[i].Bytes()
+		// Send {id, secret, publicKey, commitments} to party {i}
+	}
+}
+```
 
 ### Signing
 

--- a/frost.go
+++ b/frost.go
@@ -88,7 +88,11 @@ func SecretShareFromBytes(id, sec []byte) (*SecretShare, error) {
 
 // Initialize a new FROST State
 func NewState(c Ciphersuite, participants []*Participant, groupKey *GroupKey, msg []byte, mySecretShare *SecretShare) *State {
-	return internal.NewState(c, participants, groupKey, msg, mySecretShare.Identifier, mySecretShare)
+	var myIdentifier *Scalar
+	if mySecretShare != nil {
+		myIdentifier = mySecretShare.Identifier
+	}
+	return internal.NewState(c, participants, groupKey, msg, myIdentifier, mySecretShare)
 }
 
 // Deserialize commitments from JSON
@@ -114,4 +118,14 @@ func NewElement() *Element {
 // derives the interpolating value for a participant
 func DeriveInterpolatingValueTestingOnly(L []*Scalar, xi *Scalar) (*Scalar, error) {
 	return internal.DeriveInterpolatingValue(L, xi)
+}
+
+// ComputeBindingFactors computes the binding factors for a signing ceremony.
+func ComputeBindingFactors(c Ciphersuite, groupPublicKey *GroupKey, commitments []*Commitment, msg []byte) []*internal.BindingFactor {
+	return internal.ComputeBindingFactors(c, groupPublicKey.Element, commitments, msg)
+}
+
+// ComputeGroupCommitment computes the group commitment for a signing ceremony.
+func ComputeGroupCommitment(commitments []*Commitment, bindingFactors []*internal.BindingFactor) (*Element, error) {
+	return internal.ComputeGroupCommitment(commitments, bindingFactors)
 }

--- a/internal/ciphersuite.go
+++ b/internal/ciphersuite.go
@@ -3,6 +3,7 @@ package internal
 
 import (
 	"crypto/sha512"
+	"math/big"
 
 	"filippo.io/edwards25519"
 )
@@ -28,6 +29,7 @@ type Ciphersuite interface {
 	H3([]byte) *Scalar
 	H4([]byte) []byte
 	H5([]byte) []byte
+	Order() *big.Int
 }
 
 // Ed25519Sha512 is the ciphersuite for FROST using Ed25519 and SHA-512.
@@ -89,4 +91,11 @@ func (c *Ed25519Sha512) hashToScalar(m []byte) *Scalar {
 		panic(err)
 	}
 	return &Scalar{s: s}
+}
+
+func (c *Ed25519Sha512) Order() *big.Int {
+	// The order is 2^252 + 27742317777372353535851937790883648493
+	order := new(big.Int)
+	order.SetString("7237005577332262213973186563042994240857116359379907606001950938285454250989", 10)
+	return order
 }

--- a/internal/frost.go
+++ b/internal/frost.go
@@ -72,6 +72,10 @@ func (s *State) Sign(commitments []*Commitment) (*SignatureShare, error) {
 	}
 
 	s.challenge = ComputeChallenge(s.Ciphersuite, s.groupCommitment, s.GroupKey.Element, s.Message)
+	if s.MySecretShare == nil {
+		// An aggregation-only state allows the coordinator to compute the signature without holding a share
+		return nil, nil
+	}
 
 	participantList := ParticipantsFromCommitmentList(s.Commitments)
 	lambda_i, err := DeriveInterpolatingValue(participantList, s.MyIdentifier)
@@ -111,6 +115,10 @@ func (s *State) Aggregate(shares []*SignatureShare) (*Signature, error) {
 		R: s.groupCommitment,
 		Z: z,
 	}, nil
+}
+
+func (s *State) SetGroupCommitment(e *Element) {
+	s.groupCommitment = e
 }
 
 // VerifySignatureShare verifies a single signature share.

--- a/keygen.go
+++ b/keygen.go
@@ -1,0 +1,31 @@
+package frost
+
+import (
+	"github.com/soatok/frost/internal"
+)
+
+type KeygenOutput struct {
+	ParticipantPrivateKeys []*internal.SecretShare
+	Participants           []*internal.Participant
+	GroupPublicKey         *internal.GroupKey
+	VssCommitment          []*internal.Element
+}
+
+// Key generators should implement this interface!
+type KeyGenerator interface {
+	Keygen(maxParticipants, minParticipants uint32) (*KeygenOutput, error)
+}
+
+// How many outputs do we hold?
+func (ko KeygenOutput) Count() int {
+	return len(ko.Participants)
+}
+
+// Get the Verifiable Secret Sharing commitments for each participant
+func (ko *KeygenOutput) Commitments(index int) [][]byte {
+	out := [][]byte{}
+	for _, c := range ko.VssCommitment {
+		out = append(out, c.Bytes())
+	}
+	return out
+}

--- a/tests/integration/trusteddealer_test.go
+++ b/tests/integration/trusteddealer_test.go
@@ -1,0 +1,84 @@
+package integration
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/soatok/frost"
+	"github.com/soatok/frost/internal"
+	"github.com/soatok/frost/trusteddealer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrustedDealer(t *testing.T) {
+	c := frost.DefaultCiphersuite()
+	td := trusteddealer.NewTrustedDealer(c)
+
+	maxSigners := uint32(4)
+	minSigners := uint32(3)
+
+	// 1. KeyGen
+	keygen, err := td.Keygen(maxSigners, minSigners)
+	require.NoError(t, err)
+	require.Len(t, keygen.ParticipantPrivateKeys, 4)
+	require.Len(t, keygen.Participants, 4)
+
+	// Test VSSVerify
+	for _, p := range keygen.ParticipantPrivateKeys {
+		ok, err := trusteddealer.VssVerify(c, p, keygen.VssCommitment, minSigners)
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+
+	// 2. Round 1
+	message := []byte("it's a lovely day to save lives")
+	participants := keygen.Participants[:3]
+	secretShares := make([]*internal.SecretShare, 3)
+	for i := 0; i < 3; i++ {
+		for _, s := range keygen.ParticipantPrivateKeys {
+			if s.Identifier.Equal(participants[i].Identifier) {
+				secretShares[i] = s
+				break
+			}
+		}
+	}
+
+	states := make([]*frost.State, 3)
+	commitments := make([]*frost.Commitment, 3)
+
+	for i := range participants {
+		states[i] = frost.NewState(
+			c,
+			keygen.Participants,
+			keygen.GroupPublicKey,
+			message,
+			secretShares[i],
+		)
+		var err error
+		commitments[i], err = states[i].Commit()
+		require.NoError(t, err)
+	}
+
+	// 3. Round 2
+	shares := make([]*frost.SignatureShare, 3)
+	for i := range states {
+		var err error
+		shares[i], err = states[i].Sign(commitments)
+		require.NoError(t, err)
+	}
+
+	// 4. Aggregate
+	aggState := frost.NewState(c, keygen.Participants, keygen.GroupPublicKey, message, nil)
+	_, err = aggState.Sign(commitments)
+	require.NoError(t, err)
+
+	sig, err := aggState.Aggregate(shares)
+	require.NoError(t, err)
+
+	// 5. Verify
+	pubKeyBytes := keygen.GroupPublicKey.Element.Bytes()
+	sigBytes := sig.Bytes()
+
+	ok := ed25519.Verify(pubKeyBytes, message, sigBytes)
+	require.True(t, ok)
+}

--- a/trusteddealer/trusteddealer.go
+++ b/trusteddealer/trusteddealer.go
@@ -1,0 +1,188 @@
+package trusteddealer
+
+// Package trusteddealer implements the "Trusted Dealer" key generation strategy from
+// Appendix C of RFC 9591.
+//
+// https://www.rfc-editor.org/rfc/rfc9591.html#name-trusted-dealer-key-generati
+
+import (
+	"crypto/rand"
+	"math/big"
+
+	"filippo.io/edwards25519"
+	"github.com/soatok/frost"
+	"github.com/soatok/frost/internal"
+)
+
+type KeygenOutput = frost.KeygenOutput
+
+type TrustedDealer struct {
+	c internal.Ciphersuite
+}
+
+func NewTrustedDealer(c internal.Ciphersuite) *TrustedDealer {
+	return &TrustedDealer{c: c}
+}
+
+// Implement the interface defined in ,,/keygen.go
+func (td *TrustedDealer) Keygen(maxParticipants, minParticipants uint32) (*KeygenOutput, error) {
+	// Generate a random secret key
+	secretKeyBytes := make([]byte, 64)
+	_, err := rand.Read(secretKeyBytes)
+	if err != nil {
+		return nil, err
+	}
+	secretKey, err := edwards25519.NewScalar().SetUniformBytes(secretKeyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate random coefficients for the polynomial
+	coefficients := make([]*edwards25519.Scalar, minParticipants-1)
+	for i := range coefficients {
+		randomBytes := make([]byte, 64)
+		_, err := rand.Read(randomBytes)
+		if err != nil {
+			return nil, err
+		}
+		coefficients[i], err = edwards25519.NewScalar().SetUniformBytes(randomBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Create secret shares
+	participantPrivateKeys, fullCoefficients, err := td.secretShareShard(secretKey, coefficients, maxParticipants)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create VSS commitment
+	vssCommitment := vssCommit(fullCoefficients)
+
+	// Derive group info
+	groupPublicKey, participants, err := DeriveGroupInfo(td.c, maxParticipants, minParticipants, vssCommitment)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KeygenOutput{
+		ParticipantPrivateKeys: participantPrivateKeys,
+		Participants:           participants,
+		GroupPublicKey:         groupPublicKey,
+		VssCommitment:          vssCommitment,
+	}, nil
+}
+
+// This is where the trusted party actually performs the deal.
+// This function split the secret scalar, s, into miultiple shares.
+//
+// https://www.rfc-editor.org/rfc/rfc9591.html#name-shamir-secret-sharing
+func (td *TrustedDealer) secretShareShard(s *edwards25519.Scalar, coefficients []*edwards25519.Scalar, maxParticipants uint32) ([]*internal.SecretShare, []*edwards25519.Scalar, error) {
+	// Prepend the secret to the coefficients
+	fullCoefficients := append([]*edwards25519.Scalar{s}, coefficients...)
+
+	// Evaluate the polynomial for each point x=1,...,n
+	secretKeyShares := make([]*internal.SecretShare, maxParticipants)
+	for i := uint32(1); i <= maxParticipants; i++ {
+		x, err := internal.NewScalarFromBigInt(big.NewInt(int64(i)))
+		if err != nil {
+			return nil, nil, err
+		}
+		y := polynomialEvaluate(x.ToEd25519(), fullCoefficients)
+		yScalar, err := internal.NewScalar().SetBytes(y.Bytes())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		secretKeyShares[i-1] = &internal.SecretShare{
+			Identifier: x,
+			Scalar:     yScalar,
+		}
+	}
+	return secretKeyShares, fullCoefficients, nil
+}
+
+// Evaluate a polynomial using Horner's method.
+//
+// Because edwards25519 is constant-time, we aren't worried about leaks here:
+//
+// https://www.rfc-editor.org/rfc/rfc9591.html#name-additional-polynomial-opera
+func polynomialEvaluate(x *edwards25519.Scalar, coeffs []*edwards25519.Scalar) *edwards25519.Scalar {
+	value := edwards25519.NewScalar()
+	for i := len(coeffs) - 1; i >= 0; i-- {
+		value.Multiply(value, x)
+		value.Add(value, coeffs[i])
+	}
+	return value
+}
+
+// Security: This needs to be constant-time with respect to the coefficients.
+//
+// https://www.rfc-editor.org/rfc/rfc9591.html#name-verifiable-secret-sharing
+func vssCommit(coeffs []*edwards25519.Scalar) []*internal.Element {
+	vssCommitment := make([]*internal.Element, len(coeffs))
+	for i, coeff := range coeffs {
+		point := edwards25519.NewIdentityPoint().ScalarBaseMult(coeff)
+		vssCommitment[i] = internal.NewElementFromPoint(point)
+	}
+	return vssCommitment
+}
+
+// Every input to this method is public, so the timing leaks caused by math/big are moot.
+//
+// https://www.rfc-editor.org/rfc/rfc9591.html#name-verifiable-secret-sharing
+func VssVerify(c internal.Ciphersuite, share *internal.SecretShare, vssCommitment []*internal.Element, minParticipants uint32) (bool, error) {
+	sk_i := share.Scalar.ToEd25519()
+	s_i := edwards25519.NewIdentityPoint().ScalarBaseMult(sk_i)
+	s_i_prime := edwards25519.NewIdentityPoint()
+	iScalar := share.Identifier
+
+	for j := uint32(0); j < minParticipants; j++ {
+		pow_i_j_big := new(big.Int).Exp(iScalar.BigInt(), big.NewInt(int64(j)), c.Order())
+		pow_i_j, err := internal.NewScalarFromBigInt(pow_i_j_big)
+		if err != nil {
+			return false, err
+		}
+		term := edwards25519.NewIdentityPoint().ScalarMult(pow_i_j.ToEd25519(), vssCommitment[j].ToEd25519())
+		s_i_prime.Add(s_i_prime, term)
+	}
+
+	// Comparison of two edwards25519.Point structs uses a constant-time method under the hood:
+	return s_i.Equal(s_i_prime) == 1, nil
+}
+
+// Every input to this method is public, so the timing leaks caused by math/big are moot.
+//
+// https://www.rfc-editor.org/rfc/rfc9591.html#name-verifiable-secret-sharing
+func DeriveGroupInfo(c internal.Ciphersuite, maxParticipants, minParticipants uint32, vssCommitment []*internal.Element) (*internal.GroupKey, []*internal.Participant, error) {
+	groupPublicKey := &internal.GroupKey{Element: vssCommitment[0]}
+	participants := make([]*internal.Participant, maxParticipants)
+
+	for i := uint32(1); i <= maxParticipants; i++ {
+		pk_i := edwards25519.NewIdentityPoint()
+		iScalar, err := internal.NewScalarFromBigInt(big.NewInt(int64(i)))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for j := uint32(0); j < minParticipants; j++ {
+			pow_i_j_big := new(big.Int).Exp(iScalar.BigInt(), big.NewInt(int64(j)), c.Order())
+			pow_i_j, err := internal.NewScalarFromBigInt(pow_i_j_big)
+			if err != nil {
+				return nil, nil, err
+			}
+			term := edwards25519.NewIdentityPoint().ScalarMult(pow_i_j.ToEd25519(), vssCommitment[j].ToEd25519())
+			pk_i.Add(pk_i, term)
+		}
+		pk, err := internal.NewElement().SetBytes(pk_i.Bytes())
+		if err != nil {
+			return nil, nil, err
+		}
+		participants[i-1] = &internal.Participant{
+			Identifier:     iScalar,
+			PublicKeyShare: pk,
+		}
+	}
+	return groupPublicKey, participants, nil
+}


### PR DESCRIPTION
This implements the most basic key generation strategy, in which a "trusted dealer" generates a random key then splits it using Verifiable Secret Sharing to n participants (for which t-of-n are needed to sign messages using FROST).